### PR TITLE
Fixing compilation issues for OpenGL functions

### DIFF
--- a/cqtopencvviewergl/cqtopencvviewergl.cpp
+++ b/cqtopencvviewergl/cqtopencvviewergl.cpp
@@ -19,12 +19,12 @@ CQtOpenCVViewerGl::CQtOpenCVViewerGl(QWidget *parent) :
 void CQtOpenCVViewerGl::initializeGL()
 {
     makeCurrent();
+    initializeOpenGLFunctions();
 
-    QOpenGLFunctions *f = QOpenGLContext::currentContext()->functions();
     float r = ((float)mBgColor.darker().red())/255.0f;
     float g = ((float)mBgColor.darker().green())/255.0f;
     float b = ((float)mBgColor.darker().blue())/255.0f;
-    f->glClearColor(r,g,b,1.0f);
+    glClearColor(r,g,b,1.0f);
 
     // qglClearColor(mBgColor.darker()); obsolete
 }

--- a/cqtopencvviewergl/cqtopencvviewergl.h
+++ b/cqtopencvviewergl/cqtopencvviewergl.h
@@ -2,9 +2,10 @@
 #define CQTOPENCVVIEWERGL_H
 
 #include <QOpenGLWidget>
+#include <QOpenGLFunctions_2_0>
 #include <opencv2/core/core.hpp>
 
-class CQtOpenCVViewerGl : public QOpenGLWidget
+class CQtOpenCVViewerGl : public QOpenGLWidget, protected QOpenGLFunctions_2_0
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
This commit fixes compilation errors produced by inability of QOpenGLWidget to invoke OpenGL functions. To fix this, Qt documentation provides an example with multiple inheritance both from QOpenGLWidget and QOpenGLFunctions, which I used here.

Qt docs link: http://doc.qt.io/qt-5/qopenglwidget.html#code-examples
